### PR TITLE
Increase Nginx and PHP upload size to 16M

### DIFF
--- a/machine/etc/nginx/conf.d/sites.conf
+++ b/machine/etc/nginx/conf.d/sites.conf
@@ -1,3 +1,1 @@
 ## Override file
-
-client_max_body_size 16M;

--- a/machine/etc/nginx/conf.d/sites.conf
+++ b/machine/etc/nginx/conf.d/sites.conf
@@ -1,1 +1,3 @@
 ## Override file
+
+client_max_body_size 16M;

--- a/machine/etc/nginx/default.d/proxy.conf
+++ b/machine/etc/nginx/default.d/proxy.conf
@@ -13,6 +13,8 @@ location = /50x.html {
 # proxy PHP scripts to Varnish/Apache backend
 #
 location ~ \.php$ {
+    client_max_body_size 16M;
+
     proxy_set_header X-Real-IP  $remote_addr;
     proxy_set_header X-Forwarded-For $remote_addr;
     proxy_set_header X-Forwarded-Proto $scheme;

--- a/machine/etc/php.d/00-php.ini
+++ b/machine/etc/php.d/00-php.ini
@@ -5,6 +5,8 @@ memory_limit = 1G
 date.timezone = UTC
 session.gc_maxlifetime = 7200
 openssl.cafile = /etc/pki/tls/certs/ca-bundle.crt
+post_max_size = 16M
+upload_max_filesize = 16M
 
 [phar]
 phar.readonly = Off


### PR DESCRIPTION
I ran into an issue today where uploading a ~1.1M image to a product in the Magento 2 admin resulted in a `413 Request Entity Too Large` Nginx error.

This PR increases the `client_max_body_size` from its default of 1M to 16M, as 16M seems like a reasonable limit. I also increased PHP's `post_max_size` and `upload_max_filesize` values to 16M to match, as the 2M default seems too low.

If you think the `client_max_body_size` value should be set in a different file, let me know.
