### PR TITLE
Update php-fpm config memory usage limits

### DIFF
--- a/guest/etc/php-fpm.d/www-data.conf
+++ b/guest/etc/php-fpm.d/www-data.conf
@@ -10,9 +10,14 @@ listen.mode = 0660
 user = www-data
 group = www-data
 
+# Use something like ps_mem to determine average process memory usage
+# If average PHP process memory usage is 60MB
+# 25 children * 60M = expected typical memory usage of 1.5G
+# after 500 requests the child process will be respawned
+
 pm = static
-pm.max_children = 170
-pm.max_requests = 5000
+pm.max_children = 25
+pm.max_requests = 500
 pm.process_idle_timeout = 20s
 pm.status_path = /php-status
 


### PR DESCRIPTION
Update php-fpm config to better fit the memory usage for php processes on a 2GB node.

We may consider moving away from static process management for low traffic sites.
