### PR TITLE
Update CentOS image slug to 6.8

### DIFF
--- a/etc/defaults.rb
+++ b/etc/defaults.rb
@@ -26,7 +26,7 @@ unless defined? CONF_DO_PK_NAME
 end
 
 unless defined? CONF_DO_IMAGE
-  CONF_DO_IMAGE = 'centos-6-5-x64' # this is really CentOS 6.7 x64
+  CONF_DO_IMAGE = 'centos-6-x64' # this is really CentOS 6.8 x64
 end
 
 unless defined? CONF_DO_REGION


### PR DESCRIPTION
@davidalger 
It seems that you cannot create or rebuild a centos 6.7 image using the web interface -- it seems that DO has removed it in favor of 6.8. You can create a VM using the API with that image, but the API rejects it as a rebuild image.

So, centos 6.7 is effectively out on DO -- you can use it only via the API and you'll get inconsistent results.
