### PR TITLE
Increase the value of php max_input_vars

### DIFF
--- a/guest/etc/php.d/00-php.ini
+++ b/guest/etc/php.d/00-php.ini
@@ -7,6 +7,7 @@ session.gc_maxlifetime = 7200
 openssl.cafile = /etc/pki/tls/certs/ca-bundle.crt
 post_max_size = 16M
 upload_max_filesize = 16M
+max_input_vars = 16384
 
 [phar]
 phar.readonly = Off


### PR DESCRIPTION
See this commit and the corresponding issue it resolves for context: https://github.com/davidalger/devenv/commit/d0ca4acc62c663a51f777be21645d89f194d471a

I just ran into an issue where a client was having an issue adding more than ~100 swatches to a product attribute, which is what prompted this PR.
