### PR TITLE
Fix "Error 503 Backend fetch failed" error on large categories

### DIFF
--- a/guest/etc/sysconfig/varnish
+++ b/guest/etc/sysconfig/varnish
@@ -61,6 +61,7 @@ DAEMON_OPTS="-a ${VARNISH_LISTEN_ADDRESS}:${VARNISH_LISTEN_PORT} \
              -t ${VARNISH_TTL} \
              -p thread_pool_min=${VARNISH_MIN_THREADS} \
              -p thread_pool_max=${VARNISH_MAX_THREADS} \
+             -p http_resp_hdr_len=64000 \
              -S ${VARNISH_SECRET_FILE} \
              -s ${VARNISH_STORAGE} \
              -p cli_buffer=16384"


### PR DESCRIPTION
- I've had to make this change on three of my stage sites now, so I'm submitting a PR to fix this for future stage sites.
- See http://devdocs.magento.com/guides/v2.1/config-guide/varnish/tshoot-varnish-503.html for context